### PR TITLE
Update wildcards.py

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -198,7 +198,8 @@ def process(text, seed=None):
             keyword = match['keyword'].lower()
             quantifier = int(match['quantifier']) if match['quantifier'] else 1
             replacement = '__|__'.join([keyword,] * quantifier)
-            text = RE_WildCardQuantifier.sub(f"__{replacement}__", text)
+            RE_TEMP = re.compile(fr"(?P<quantifier>\d+)#__(?P<keyword>{keyword})__", re.IGNORECASE)
+            text = RE_TEMP.sub(f"__{replacement}__", text)
 
         # pass1: replace options
         pass1, is_replaced1 = replace_options(text)


### PR DESCRIPTION
Fixed a big issue of the new wildcard multi-select-pattern quantifier that replaced all sub-subsequent occurrences of the wildcard keyword with the 1st occurrence's keyword, utterly destroying the prompt's identity.